### PR TITLE
Update MongoDB version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,7 +223,7 @@ services:
     mongodb:
         container_name: linshare_mongodb
         restart: on-failure
-        image: mongo:4.2
+        image: mongo:5.0
         environment:
             - MONGO_INITDB_ROOT_USERNAME=linshare
             - MONGO_INITDB_ROOT_PASSWORD=linshare


### PR DESCRIPTION
Hi, 

According to [LinShare requirements](https://github.com/linagora/linshare/blob/master/documentation/EN/installation/requirements.md), since LinShare version 6.0, MongoDB has to be in version 5.0.

I updated the MongoDB dependency in `docker-compose.yml` file.